### PR TITLE
Added basic support for stripping tags or ignoring colors

### DIFF
--- a/ansiproperties.go
+++ b/ansiproperties.go
@@ -74,8 +74,10 @@ func (p ansiProperties) PropagateAnsiCode(previous *ansiProperties) string {
 		}
 	}
 
+	if p.fg == 0 && p.bg == 0 {
+		return ""
+	}
 	return "\033[" + strconv.Itoa(p.fg) + ";" + strconv.Itoa(p.bg) + "m"
-
 }
 
 func AnsiResetAll() string {

--- a/ansitags_test.go
+++ b/ansitags_test.go
@@ -35,6 +35,44 @@ func TestParse(t *testing.T) {
 
 }
 
+func TestParseStripped(t *testing.T) {
+
+	testTable := loadTestFile("testdata/ansitags_test_strip.yaml")
+
+	for name, testCase := range testTable {
+
+		t.Run(name, func(t *testing.T) {
+
+			output := Parse(testCase.Input, stripTags)
+			assert.Equal(t, testCase.Expected, output)
+
+			// fmt.Println(output)
+			//bytes, _ := json.Marshal(output)
+			//fmt.Println(string(bytes))
+		})
+	}
+
+}
+
+func TestParseMono(t *testing.T) {
+
+	testTable := loadTestFile("testdata/ansitags_test_monochrome.yaml")
+
+	for name, testCase := range testTable {
+
+		t.Run(name, func(t *testing.T) {
+
+			output := Parse(testCase.Input, monoChrome)
+			assert.Equal(t, testCase.Expected, output)
+
+			// fmt.Println(output)
+			//bytes, _ := json.Marshal(output)
+			//fmt.Println(string(bytes))
+		})
+	}
+
+}
+
 func TestParseLarge(t *testing.T) {
 
 	testString := loadRawFile("testdata/ansitags_streaming_test.yaml")

--- a/testdata/ansitags_test.yaml
+++ b/testdata/ansitags_test.yaml
@@ -1,6 +1,9 @@
 #
 # "expected" (output) should be properly unicode escaped - using json.Marshal on strings works well for this
 #
+No Tag:
+    input: "This string has no ansi tags"
+    expected: "This string has no ansi tags"
 Named Colors:
     input: "<ansi fg=black bg=\"white\">A</ansi><ansi fg=\"red\" bg=\"cyan\">B</ansi><ansi fg=\"green\" bg=\"magenta\">C</ansi><ansi fg=\"yellow\" bg=\"blue\">D</ansi><ansi fg=\"blue\" bg=\"yellow\">E</ansi><ansi fg=\"magenta\" bg=\"green\">F</ansi><ansi fg=\"cyan\" bg=\"red\">G</ansi><ansi fg=\"white\" bg=\"black\">H</ansi>"
     expected: "\u001b[30;47mA\u001b[0m\u001b[31;46mB\u001b[0m\u001b[32;45mC\u001b[0m\u001b[33;44mD\u001b[0m\u001b[34;43mE\u001b[0m\u001b[35;42mF\u001b[0m\u001b[36;41mG\u001b[0m\u001b[37;40mH\u001b[0m"

--- a/testdata/ansitags_test_monochrome.yaml
+++ b/testdata/ansitags_test_monochrome.yaml
@@ -1,0 +1,9 @@
+No Tag:
+    input: "This string has no ansi tags"
+    expected: "This string has no ansi tags"
+Named Colors:
+    input: "<ansi fg=black bg=\"white\">A</ansi><ansi fg=\"red\" bg=\"cyan\">B</ansi><ansi fg=\"green\" bg=\"magenta\">C</ansi><ansi fg=\"yellow\" bg=\"blue\">D</ansi><ansi fg=\"blue\" bg=\"yellow\">E</ansi><ansi fg=\"magenta\" bg=\"green\">F</ansi><ansi fg=\"cyan\" bg=\"red\">G</ansi><ansi fg=\"white\" bg=\"black\">H</ansi>"
+    expected: "A\x1b[0mB\x1b[0mC\x1b[0mD\x1b[0mE\x1b[0mF\x1b[0mG\x1b[0mH\x1b[0m"
+No Close Tag:
+    input: "<ansi fg='blue'>This is inside of ansi tags"
+    expected: "This is inside of ansi tags\x1b[0m"

--- a/testdata/ansitags_test_strip.yaml
+++ b/testdata/ansitags_test_strip.yaml
@@ -1,0 +1,9 @@
+No Tag:
+    input: "This string has no ansi tags"
+    expected: "This string has no ansi tags"
+Named Colors:
+    input: "<ansi fg=black bg=\"white\">A</ansi><ansi fg=\"red\" bg=\"cyan\">B</ansi><ansi fg=\"green\" bg=\"magenta\">C</ansi><ansi fg=\"yellow\" bg=\"blue\">D</ansi><ansi fg=\"blue\" bg=\"yellow\">E</ansi><ansi fg=\"magenta\" bg=\"green\">F</ansi><ansi fg=\"cyan\" bg=\"red\">G</ansi><ansi fg=\"white\" bg=\"black\">H</ansi>"
+    expected: "ABCDEFGH"
+No Close Tag:
+    input: "<ansi fg='blue'>This is inside of ansi tags"
+    expected: "This is inside of ansi tags"


### PR DESCRIPTION
# Description

This adds some rudimentary support for behavior flags while parsing. In this change we include the ability to strip out all tags (no resulting ansi escape codes) and ignore fg/bg color changes.

# Changes
Updated `Parse()` and `ParseStreaming()` to accept behavior flags as arguments:
* `stripTags` - Strips out all `<ansi></ansi>` tags but keeps text intact.
* `monoChrome` - Maintains ansi escape code parsing, but ignores foreground and background color changes.
