### PR TITLE
Renaming old repo path to new org repo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _ansitags_ is a helper library that allows to you use common tags inside of text
 
 Import the module:
 
-    import "github.com/Volte6/ansitags"
+    import "github.com/GoMudEngine/ansitags"
 
 Parse and print a string:
 

--- a/example/main.go
+++ b/example/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/Volte6/ansitags"
+	"github.com/GoMudEngine/ansitags"
 )
 
 // accepts a string via shell pipe and processes with ansitags.Parse()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Volte6/ansitags
+module github.com/GoMudEngine/ansitags
 
 go 1.18
 

--- a/testdata/coverage_tests.html
+++ b/testdata/coverage_tests.html
@@ -55,11 +55,11 @@
 			<div id="nav">
 				<select id="files">
 				
-				<option value="file0">github.com/Volte6/ansitags/ansitags.go (100.0%)</option>
+				<option value="file0">github.com/GoMudEngine/ansitags/ansitags.go (100.0%)</option>
 				
-				<option value="file1">github.com/Volte6/ansitags/ansiproperties.go (96.8%)</option>
+				<option value="file1">github.com/GoMudEngine/ansitags/ansiproperties.go (96.8%)</option>
 				
-				<option value="file2">github.com/Volte6/ansitags/tagmatcher.go (100.0%)</option>
+				<option value="file2">github.com/GoMudEngine/ansitags/tagmatcher.go (100.0%)</option>
 				
 				</select>
 			</div>


### PR DESCRIPTION
# Changes

* Renaming references `github.com/Volte6/ansitags` => `github.com/GoMudEngine/ansitags`