### PR TITLE
Alias set functions, bug fixes, and more

### DIFF
--- a/ansiproperties.go
+++ b/ansiproperties.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 type ColorMode uint8
@@ -89,6 +90,8 @@ var (
 	}
 
 	colorMode ColorMode = Color8
+
+	rwLock = sync.RWMutex{}
 )
 
 type ansiProperties struct {

--- a/ansitags_test.go
+++ b/ansitags_test.go
@@ -16,6 +16,25 @@ type TestCase struct {
 	Expected string `yaml:"expected"`
 }
 
+func TestParseTagOpenerMismatches(t *testing.T) {
+
+	testTable := loadTestFile("testdata/ansitags_test_tag_openers.yaml")
+
+	for name, testCase := range testTable {
+
+		t.Run(name, func(t *testing.T) {
+
+			output := Parse(testCase.Input)
+			assert.Equal(t, testCase.Expected, output)
+
+			//fmt.Println(output)
+			//bytes, _ := json.Marshal(output)
+			//fmt.Println(string(bytes))
+		})
+	}
+
+}
+
 func TestParseAliases(t *testing.T) {
 
 	testTable := loadTestFile("testdata/ansitags_test_aliases.yaml")
@@ -165,6 +184,91 @@ func loadRawFile(filename string) string {
 	}
 
 	return string(yfile)
+}
+
+func TestSetAliasValidDefaultGroup(t *testing.T) {
+	alias := "testAlias256"
+	value := 123
+	// Ensure clean state
+	delete(colorMap256, alias)
+	// Set alias in default (color256) group
+	if err := SetAlias(alias, value); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := colorMap256[alias]; got != value {
+		t.Errorf("colorMap256[%q] = %d; want %d", alias, got, value)
+	}
+}
+
+func TestSetAliasValidColor8Group(t *testing.T) {
+	alias := "testAlias8"
+	value := 45
+	delete(colorMap8, alias)
+	// Set alias in color8 group
+	if err := SetAlias(alias, value, "color8"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if got := colorMap8[alias]; got != value {
+		t.Errorf("colorMap8[%q] = %d; want %d", alias, got, value)
+	}
+}
+
+func TestSetAliasInvalidValue(t *testing.T) {
+	alias := "invalidAlias"
+	invalidValue := -5
+	// Expect error for out-of-range value
+	if err := SetAlias(alias, invalidValue); err == nil {
+		t.Errorf("expected error for invalid value %d, got none", invalidValue)
+	}
+}
+
+func TestSetAliasesValidDefaultGroup(t *testing.T) {
+	aliases := map[string]int{
+		"multi256_1": 200,
+		"multi256_2": 201,
+	}
+	delete(colorMap256, "multi256_1")
+	delete(colorMap256, "multi256_2")
+	// Bulk set in default (color256) group
+	if err := SetAliases(aliases); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for alias, expected := range aliases {
+		if got := colorMap256[alias]; got != expected {
+			t.Errorf("colorMap256[%q] = %d; want %d", alias, got, expected)
+		}
+	}
+}
+
+func TestSetAliasesValidColor8Group(t *testing.T) {
+	aliases := map[string]int{
+		"multi8_1": 10,
+		"multi8_2": 20,
+	}
+	delete(colorMap8, "multi8_1")
+	delete(colorMap8, "multi8_2")
+	// Bulk set in color8 group
+	if err := SetAliases(aliases, "color8"); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	for alias, expected := range aliases {
+		if got := colorMap8[alias]; got != expected {
+			t.Errorf("colorMap8[%q] = %d; want %d", alias, got, expected)
+		}
+	}
+}
+
+func TestSetAliasesInvalidValue(t *testing.T) {
+	aliases := map[string]int{
+		"badAlias1": -1,
+		"badAlias2": 300,
+	}
+	delete(colorMap256, "badAlias1")
+	delete(colorMap256, "badAlias2")
+	// Expect error and no partial application
+	if err := SetAliases(aliases); err == nil {
+		t.Fatalf("expected error for invalid alias value, got none")
+	}
 }
 
 //

--- a/testdata/ansitags_test_tag_openers.yaml
+++ b/testdata/ansitags_test_tag_openers.yaml
@@ -1,0 +1,9 @@
+No Tag:
+    input: "This string has no ansi tags"
+    expected: "This string has no ansi tags"
+Non Tags:
+    input: "<this is just> some <text"
+    expected: "<this is just> some <text"
+Tags with Non Tags:
+    input: "<ansi fg='blue'>This is in<side of ansi tags</ansi>"
+    expected: "\x1b[34;49mThis is in<side of ansi tags\x1b[0m"


### PR DESCRIPTION
# Changes

* Added a RWMutex for when updating color aliases or parsing strings
* Fixed [bug](https://github.com/GoMudEngine/ansitags/issues/10) and included tests for it.
* New functions `SetAlias()` and `SetAliases()` to set/override specific aliases
* `LoadAliases()` now has a variadic argument, allowing multiple files to be loaded in sequence.
